### PR TITLE
all: fix gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /.github/workflows/*.yml linguist-generated
-/cue.mod/pkg/* linguist-generated
+/cue.mod/pkg/**/* linguist-generated
+/action.yml linguist-generated


### PR DESCRIPTION
The syntax was incorrect for both sets of ignored files. Start to the
day.

Signed-off-by: Paul Jolly <paul@myitcv.io>