### PR TITLE
action: support pre-v0.3.0 artifact naming scheme

### DIFF
--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -73,6 +73,17 @@ describe('Testing all functions in run file.', () => {
     });
 
     test.each([
+        ['arm64', 'arm64'],
+        ['amd64', 'x86_64']
+    ])('getCuectlDownloadURL() must return the URL to download older %s cuectl for Linux based systems', (arch, releaseArch) => {
+        jest.spyOn(os, 'type').mockReturnValue('Linux');
+        const cuectlLinuxUrl = util.format('https://github.com/cue-lang/cue/releases/download/v0.2.2/cue_0.2.2_Linux_%s.tar.gz', releaseArch);
+
+        expect(run.getCuectlDownloadURL('v0.2.2', arch)).toBe(cuectlLinuxUrl);
+        expect(os.type).toBeCalled();
+    });
+
+    test.each([
         ['arm64'],
         ['amd64']
     ])('getCuectlDownloadURL() must return the URL to download %s cuectl for MacOS based systems', (arch) => {
@@ -84,12 +95,32 @@ describe('Testing all functions in run file.', () => {
     });
 
     test.each([
+        ['amd64', 'x86_64']
+    ])('getCuectlDownloadURL() must return the URL to download older %s cuectl for MacOS based systems', (arch, releaseArch) => {
+        jest.spyOn(os, 'type').mockReturnValue('Darwin');
+        const cuectlDarwinUrl = util.format('https://github.com/cue-lang/cue/releases/download/v0.2.2/cue_0.2.2_Darwin_%s.tar.gz', releaseArch);
+
+        expect(run.getCuectlDownloadURL('v0.2.2', arch)).toBe(cuectlDarwinUrl);
+        expect(os.type).toBeCalled();
+    });
+
+    test.each([
         ['amd64']
     ])('getCuectlDownloadURL() must return the URL to download %s cuectl for Windows based systems', (arch) => {
         jest.spyOn(os, 'type').mockReturnValue('Windows_NT');
         const cuectlWindowsUrl = util.format('https://github.com/cue-lang/cue/releases/download/v0.4.0/cue_v0.4.0_windows_%s.zip', arch);
 
         expect(run.getCuectlDownloadURL('v0.4.0', arch)).toBe(cuectlWindowsUrl);
+        expect(os.type).toBeCalled();
+    });
+
+    test.each([
+        ['amd64', 'x86_64']
+    ])('getCuectlDownloadURL() must return the URL to download older %s cuectl for Windows based systems', (arch, releaseArch) => {
+        jest.spyOn(os, 'type').mockReturnValue('Windows_NT');
+        const cuectlWindowsUrl = util.format('https://github.com/cue-lang/cue/releases/download/v0.2.2/cue_0.2.2_Windows_%s.zip', releaseArch);
+
+        expect(run.getCuectlDownloadURL('v0.2.2', arch)).toBe(cuectlWindowsUrl);
         expect(os.type).toBeCalled();
     });
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -24,6 +24,7 @@ import * as semver from 'semver';
 const cuectlToolName = 'cue';
 const stableCuectlVersion = 'v0.4.0';
 const cuectlAllReleasesUrl = 'https://api.github.com/repos/cue-lang/cue/releases';
+const downloadReleaseUrlBase = 'https://github.com/cue-lang/cue/releases/download';
 
 export function getExecutableExtension(): string {
     if (os.type().match(/^Win/)) {
@@ -69,17 +70,28 @@ export async function getLatestCuectlVersion(): Promise<string> {
 }
 
 export function getCuectlDownloadURL(version: string, arch: string): string {
-    switch (os.type()) {
-        case 'Linux':
-            return util.format('https://github.com/cue-lang/cue/releases/download/%s/cue_%s_linux_%s.tar.gz', version, version, arch);
-
-        case 'Darwin':
-            return util.format('https://github.com/cue-lang/cue/releases/download/%s/cue_%s_darwin_%s.tar.gz', version, version, arch);
-
-        case 'Windows_NT':
-        default:
-            return util.format('https://github.com/cue-lang/cue/releases/download/%s/cue_%s_windows_%s.zip', version, version, arch);
-
+    let cleanVersion = semver.clean(version);
+    if (semver.lt(cleanVersion, '0.3.0')) {
+        let releaseArch = (arch == 'amd64') ? 'x86_64' : arch;
+        switch (os.type()) {
+            case 'Linux':
+                return util.format('%s/%s/cue_%s_Linux_%s.tar.gz', downloadReleaseUrlBase, version, cleanVersion, releaseArch);
+            case 'Darwin':
+                return util.format('%s/%s/cue_%s_Darwin_%s.tar.gz', downloadReleaseUrlBase, version, cleanVersion, releaseArch);
+            case 'Windows_NT':
+            default:
+                return util.format('%s/%s/cue_%s_Windows_%s.zip', downloadReleaseUrlBase, version, cleanVersion, releaseArch);
+        }
+    } else {
+        switch (os.type()) {
+            case 'Linux':
+                return util.format('%s/%s/cue_%s_linux_%s.tar.gz', downloadReleaseUrlBase, version, version, arch);
+            case 'Darwin':
+                return util.format('%s/%s/cue_%s_darwin_%s.tar.gz', downloadReleaseUrlBase, version, version, arch);
+            case 'Windows_NT':
+            default:
+                return util.format('%s/%s/cue_%s_windows_%s.zip', downloadReleaseUrlBase, version, version, arch);
+        }
     }
 }
 


### PR DESCRIPTION
This action is unable to fetch releases older than 0.3.0 since the artifact naming scheme was different for older releases.

https://github.com/cue-lang/cue/releases/download/v0.2.2/cue_0.2.2_Darwin_x86_64.tar.gz
vs
https://github.com/cue-lang/cue/releases/download/v0.4.2/cue_v0.4.2_darwin_amd64.tar.gz