### PR TITLE
Fix release tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ latest stable release of `cue`. Releases of `cue` are listed
 [here](https://github.com/cue-lang/cue/releases).
 
 ```
-- uses: cue-lang/setup-cue@v1
+- uses: cue-lang/setup-cue@v0.0.1
   with:
     version: '<version>' # default is latest
   id: install


### PR DESCRIPTION
There is no `v1` in Releases. `v0.0.1` is fine.
<img width="774" alt="image" src="https://user-images.githubusercontent.com/56793934/206210658-fcec4786-bc1b-4aee-9f3e-51110401aa8f.png">

[GitHub Actions](https://github.com/dubs11kt/kubernetes-manifests/actions/runs/3639897402/jobs/6143856157)