### PR TITLE
bump to use and support node24

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use node.js 20.x
+      - name: Use node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Use CUE
         uses: ./
         with:

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -54,7 +54,7 @@ describe('Testing all functions in run file.', () => {
         ['arm', 'arm'],
         ['arm64', 'arm64'],
         ['x64', 'amd64']
-    ])("getCuectlArch() must return on %s os architecture %s cuectl architecture", (osArch, cuectlVersion) => {
+    ] as const)("getCuectlArch() must return on %s os architecture %s cuectl architecture", (osArch, cuectlVersion) => {
         jest.spyOn(os, 'arch').mockReturnValue(osArch);
 
         expect(run.getCuectlOSArchitecture()).toBe(cuectlVersion);

--- a/action.cue
+++ b/action.cue
@@ -16,7 +16,7 @@ action: github.#Action & {
 		color: "blue"
 	}
 	runs: {
-		using: "node20"
+		using: "node24"
 		main:  "dist/index.js"
 	}
 }

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ outputs:
   cue-path:
     description: Path to the cached CUE binary
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 branding:
   color: blue

--- a/ci_tool.cue
+++ b/ci_tool.cue
@@ -27,7 +27,7 @@ command: vendorgithubschema: {
 	getActionJSONSchema: http.Get & {
 		// Tip link for humans:
 		// https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-action.json
-		url: "https://raw.githubusercontent.com/SchemaStore/schemastore/c3d4b35e7bbd40b2a95191e393f8c0bad340e97f/src/schemas/json/github-action.json"
+		url: "https://raw.githubusercontent.com/SchemaStore/schemastore/01e00802b38350cb7ec257b11c456639a5cd0acf/src/schemas/json/github-action.json"
 	}
 
 	importActionJSONSchema: exec.Run & {

--- a/cue.mod/pkg/json.schemastore.org/github/github-action.cue
+++ b/cue.mod/pkg/json.schemastore.org/github/github-action.cue
@@ -45,10 +45,10 @@ package github
 	// to your action name in GitHub Marketplace.
 	branding?: {
 		// The background color of the badge.
-		color?: "white" | "yellow" | "blue" | "green" | "orange" | "red" | "purple" | "gray-dark"
+		color?: "white" | "black" | "yellow" | "blue" | "green" | "orange" | "red" | "purple" | "gray-dark"
 
 		// The name of the Feather icon to use.
-		icon?: "activity" | "airplay" | "alert-circle" | "alert-octagon" | "alert-triangle" | "align-center" | "align-justify" | "align-left" | "align-right" | "anchor" | "aperture" | "archive" | "arrow-down-circle" | "arrow-down-left" | "arrow-down-right" | "arrow-down" | "arrow-left-circle" | "arrow-left" | "arrow-right-circle" | "arrow-right" | "arrow-up-circle" | "arrow-up-left" | "arrow-up-right" | "arrow-up" | "at-sign" | "award" | "bar-chart-2" | "bar-chart" | "battery-charging" | "battery" | "bell-off" | "bell" | "bluetooth" | "bold" | "book-open" | "book" | "bookmark" | "box" | "briefcase" | "calendar" | "camera-off" | "camera" | "cast" | "check-circle" | "check-square" | "check" | "chevron-down" | "chevron-left" | "chevron-right" | "chevron-up" | "chevrons-down" | "chevrons-left" | "chevrons-right" | "chevrons-up" | "circle" | "clipboard" | "clock" | "cloud-drizzle" | "cloud-lightning" | "cloud-off" | "cloud-rain" | "cloud-snow" | "cloud" | "code" | "command" | "compass" | "copy" | "corner-down-left" | "corner-down-right" | "corner-left-down" | "corner-left-up" | "corner-right-down" | "corner-right-up" | "corner-up-left" | "corner-up-right" | "cpu" | "credit-card" | "crop" | "crosshair" | "database" | "delete" | "disc" | "dollar-sign" | "download-cloud" | "download" | "droplet" | "edit-2" | "edit-3" | "edit" | "external-link" | "eye-off" | "eye" | "facebook" | "fast-forward" | "feather" | "file-minus" | "file-plus" | "file-text" | "file" | "film" | "filter" | "flag" | "folder-minus" | "folder-plus" | "folder" | "gift" | "git-branch" | "git-commit" | "git-merge" | "git-pull-request" | "globe" | "grid" | "hard-drive" | "hash" | "headphones" | "heart" | "help-circle" | "home" | "image" | "inbox" | "info" | "italic" | "layers" | "layout" | "life-buoy" | "link-2" | "link" | "list" | "loader" | "lock" | "log-in" | "log-out" | "mail" | "map-pin" | "map" | "maximize-2" | "maximize" | "menu" | "message-circle" | "message-square" | "mic-off" | "mic" | "minimize-2" | "minimize" | "minus-circle" | "minus-square" | "minus" | "monitor" | "moon" | "more-horizontal" | "more-vertical" | "move" | "music" | "navigation-2" | "navigation" | "octagon" | "package" | "paperclip" | "pause-circle" | "pause" | "percent" | "phone-call" | "phone-forwarded" | "phone-incoming" | "phone-missed" | "phone-off" | "phone-outgoing" | "phone" | "pie-chart" | "play-circle" | "play" | "plus-circle" | "plus-square" | "plus" | "pocket" | "power" | "printer" | "radio" | "refresh-ccw" | "refresh-cw" | "repeat" | "rewind" | "rotate-ccw" | "rotate-cw" | "rss" | "save" | "scissors" | "search" | "send" | "server" | "settings" | "share-2" | "share" | "shield-off" | "shield" | "shopping-bag" | "shopping-cart" | "shuffle" | "sidebar" | "skip-back" | "skip-forward" | "slash" | "sliders" | "smartphone" | "speaker" | "square" | "star" | "stop-circle" | "sun" | "sunrise" | "sunset" | "tablet" | "tag" | "target" | "terminal" | "thermometer" | "thumbs-down" | "thumbs-up" | "toggle-left" | "toggle-right" | "trash-2" | "trash" | "trending-down" | "trending-up" | "triangle" | "truck" | "tv" | "type" | "umbrella" | "underline" | "unlock" | "upload-cloud" | "upload" | "user-check" | "user-minus" | "user-plus" | "user-x" | "user" | "users" | "video-off" | "video" | "voicemail" | "volume-1" | "volume-2" | "volume-x" | "volume" | "watch" | "wifi-off" | "wifi" | "wind" | "x-circle" | "x-square" | "x" | "zap-off" | "zap" | "zoom-in" | "zoom-out"
+		icon?: "activity" | "airplay" | "alert-circle" | "alert-octagon" | "alert-triangle" | "align-center" | "align-justify" | "align-left" | "align-right" | "anchor" | "aperture" | "archive" | "arrow-down-circle" | "arrow-down-left" | "arrow-down-right" | "arrow-down" | "arrow-left-circle" | "arrow-left" | "arrow-right-circle" | "arrow-right" | "arrow-up-circle" | "arrow-up-left" | "arrow-up-right" | "arrow-up" | "at-sign" | "award" | "bar-chart-2" | "bar-chart" | "battery-charging" | "battery" | "bell-off" | "bell" | "bluetooth" | "bold" | "book-open" | "book" | "bookmark" | "box" | "briefcase" | "calendar" | "camera-off" | "camera" | "cast" | "check-circle" | "check-square" | "check" | "chevron-down" | "chevron-left" | "chevron-right" | "chevron-up" | "chevrons-down" | "chevrons-left" | "chevrons-right" | "chevrons-up" | "circle" | "clipboard" | "clock" | "cloud-drizzle" | "cloud-lightning" | "cloud-off" | "cloud-rain" | "cloud-snow" | "cloud" | "code" | "command" | "compass" | "copy" | "corner-down-left" | "corner-down-right" | "corner-left-down" | "corner-left-up" | "corner-right-down" | "corner-right-up" | "corner-up-left" | "corner-up-right" | "cpu" | "credit-card" | "crop" | "crosshair" | "database" | "delete" | "disc" | "dollar-sign" | "download-cloud" | "download" | "droplet" | "edit-2" | "edit-3" | "edit" | "external-link" | "eye-off" | "eye" | "fast-forward" | "feather" | "file-minus" | "file-plus" | "file-text" | "file" | "film" | "filter" | "flag" | "folder-minus" | "folder-plus" | "folder" | "gift" | "git-branch" | "git-commit" | "git-merge" | "git-pull-request" | "globe" | "grid" | "hard-drive" | "hash" | "headphones" | "heart" | "help-circle" | "home" | "image" | "inbox" | "info" | "italic" | "layers" | "layout" | "life-buoy" | "link-2" | "link" | "list" | "loader" | "lock" | "log-in" | "log-out" | "mail" | "map-pin" | "map" | "maximize-2" | "maximize" | "menu" | "message-circle" | "message-square" | "mic-off" | "mic" | "minimize-2" | "minimize" | "minus-circle" | "minus-square" | "minus" | "monitor" | "moon" | "more-horizontal" | "more-vertical" | "move" | "music" | "navigation-2" | "navigation" | "octagon" | "package" | "paperclip" | "pause-circle" | "pause" | "percent" | "phone-call" | "phone-forwarded" | "phone-incoming" | "phone-missed" | "phone-off" | "phone-outgoing" | "phone" | "pie-chart" | "play-circle" | "play" | "plus-circle" | "plus-square" | "plus" | "pocket" | "power" | "printer" | "radio" | "refresh-ccw" | "refresh-cw" | "repeat" | "rewind" | "rotate-ccw" | "rotate-cw" | "rss" | "save" | "scissors" | "search" | "send" | "server" | "settings" | "share-2" | "share" | "shield-off" | "shield" | "shopping-bag" | "shopping-cart" | "shuffle" | "sidebar" | "skip-back" | "skip-forward" | "slash" | "sliders" | "smartphone" | "speaker" | "square" | "star" | "stop-circle" | "sun" | "sunrise" | "sunset" | "table" | "tablet" | "tag" | "target" | "terminal" | "thermometer" | "thumbs-down" | "thumbs-up" | "toggle-left" | "toggle-right" | "trash-2" | "trash" | "trending-down" | "trending-up" | "triangle" | "truck" | "tv" | "type" | "umbrella" | "underline" | "unlock" | "upload-cloud" | "upload" | "user-check" | "user-minus" | "user-plus" | "user-x" | "user" | "users" | "video-off" | "video" | "voicemail" | "volume-1" | "volume-2" | "volume-x" | "volume" | "watch" | "wifi-off" | "wifi" | "wind" | "x-circle" | "x-square" | "x" | "zap-off" | "zap" | "zoom-in" | "zoom-out"
 	}
 
 	#expressionSyntax: =~"""
@@ -67,7 +67,7 @@ package github
 
 	#: "runs-javascript": {
 		// The application used to execute the code specified in `main`.
-		using: "node12" | "node16" | "node20"
+		using: "node12" | "node16" | "node20" | "node24"
 
 		// The file that contains your action code. The application
 		// specified in `using` executes this file.
@@ -134,14 +134,17 @@ package github
 			// unless a condition is met. You can use any supported context
 			// and expression to create a conditional.
 			// Expressions in an if conditional do not require the ${{ }}
-			// syntax. For more information, see
-			// https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.
+			// syntax. However, you must always use the ${{ }} expression
+			// syntax or escape with '', "", or () when the expression starts
+			// with !, since ! is reserved notation in YAML format. For more
+			// information, see
+			// https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions
 			if?: string
 
 			// Sets a map of environment variables for only that step.
 			env?: {
-				[string]: string
-			}
+				[string]: bool | number | string
+			} | #stringContainingExpressionSyntax
 
 			// Prevents a job from failing when a step fails. Set to true to
 			// allow a job to pass when this step fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/jest": "27.5.2",
-        "@types/node": "20.11.10",
+        "@types/node": "24.13.3",
         "@types/semver": "7.3.13",
         "@vercel/ncc": "0.33.4",
         "jest": "29.0.0",
@@ -1219,12 +1219,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
-      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/semver": {
@@ -1983,6 +1984,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -4098,10 +4114,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "Apache 2.0",
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "20.11.10",
+    "@types/node": "24.13.3",
     "@types/semver": "7.3.13",
     "@vercel/ncc": "0.33.4",
     "jest": "29.0.0",

--- a/workflows.cue
+++ b/workflows.cue
@@ -33,9 +33,9 @@ buildAndTest: github.#Workflow & {
 				uses: "actions/checkout@v4"
 			},
 			{
-				name: "Use node.js 20.x"
+				name: "Use node.js 24.x"
 				uses: "actions/setup-node@v4"
-				with: "node-version": 20
+				with: "node-version": 24
 			},
 			{
 				name: "Use CUE"


### PR DESCRIPTION
## Summary
- Bump the action runtime from `node20` to `node24` in `action.cue`/`action.yml`
- Bump the CI workflow's `actions/setup-node` step to `node-version: 24` in `workflows.cue`/`.github/workflows/build-and-test.yml`
- Re-vendor the GitHub Action JSON Schema (`cue cmd vendorgithubschema`) so `runs.using` allows `node24`, and bump the pinned SchemaStore commit in `ci_tool.cue`
- Bump `@types/node` to `24.13.3` in `package.json`/`package-lock.json`
- Add `as const` to a `test.each` array in `__tests__/run.test.ts` to satisfy the stricter `NodeJS.Architecture` typing that ships with `@types/node@24`

## Test plan
- [x] `npm run build`
- [x] `npm test` (14 tests passing)
- [x] `npm run dist` (bundle output unchanged aside from type-only deps)
- [x] `cue vet ./...`

---
This PR was created with [Claude Code](https://claude.com/claude-code).

## Note

* We are facing deprecations on GitHub Actions.

```
* Node.js 20 is deprecated on GitHub Actions runners when use this actions.

GitHub Actions runners are forcing workflows that target Node.js 20 to run on Node.js 24 instead. The actions actions/checkout@v4 and actions/setup-node@v4 in this workflow still target Node 20 (from GitHub's side, unrelated to our own node20→node24 bump), which triggers this warning. If Node 20 is temporarily needed, the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable can be set. More details: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```